### PR TITLE
refactor(*): Updated c360 to use wes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The directory structure looks like this:
 
 ```
 scripts/
-  └── copy-resources.mjs                // copy useful files to assets (ie c360 stylehooks)
+  └── copy-resources.mjs                // copy useful files to assets (ie wes stylehooks)
 src/
   ├── assets/                           // static assets
   │   └── css/
@@ -41,8 +41,8 @@ The LWR server is configured in `lwr.config.json`, at the root of the project.
             "dir": "$rootDir/src/modules" 
         },
         {
-            "name": "@salesforce-ux/c360-grid/dist/index.css",
-            "path": "./node_modules/@salesforce-ux/c360-grid/dist/index.css"
+            "name": "@salesforce-ux/wes-grid/dist/index.css",
+            "path": "./node_modules/@salesforce-ux/wes-grid/dist/index.css"
         },
         {
         "npm": "@oneappexchange/appx-design-system"

--- a/lwr.config.json
+++ b/lwr.config.json
@@ -5,8 +5,8 @@
         "dir": "$rootDir/src/modules"
       },
       {
-        "name": "@salesforce-ux/c360-grid/dist/index.css",
-        "path": "./node_modules/@salesforce-ux/c360-grid/dist/index.css"
+        "name": "@salesforce-ux/wes-grid/dist/index.css",
+        "path": "./node_modules/@salesforce-ux/wes-grid/dist/index.css"
       },
       {
         "npm": "@oneappexchange/appx-design-system"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "start:prod-compat": "lwr serve --mode prod-compat"
   },
   "dependencies": {
-    "@oneappexchange/appx-design-system": "0.0.1-alpha.5",
-    "@salesforce-ux/c360-grid": "^0.1.5",
-    "@salesforce-ux/c360-styling-hooks": "^0.2.2",
+    "@oneappexchange/appx-design-system": "^0.0.1-alpha.7",
+    "@salesforce-ux/wes-grid": "^0.0.1",
+    "@salesforce-ux/wes-styling-hooks": "^0.0.1",
     "cpx": "^1.5.0",
     "lwc": "2.5.8",
     "lwr": "0.6.0-alpha.14"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:prod-compat": "lwr serve --mode prod-compat"
   },
   "dependencies": {
-    "@oneappexchange/appx-design-system": "^0.0.1-alpha.7",
+    "@oneappexchange/appx-design-system": "^0.0.1-alpha.8",
     "@salesforce-ux/wes-grid": "^0.0.1",
     "@salesforce-ux/wes-styling-hooks": "^0.0.1",
     "cpx": "^1.5.0",

--- a/scripts/copy-resources.mjs
+++ b/scripts/copy-resources.mjs
@@ -3,7 +3,7 @@ import { log } from 'console'
 
 // Copy the SDS resources to the assets dir
 cpx.copy(
-  './node_modules/@salesforce-ux/c360-styling-hooks/dist/hooks.custom-props.css',
+  './node_modules/@salesforce-ux/wes-styling-hooks/dist/hooks.custom-props.css',
   'src/assets/css',
   () => log(`Done copying SDS stylehooks`)
 )

--- a/src/assets/css/hooks.custom-props.css
+++ b/src/assets/css/hooks.custom-props.css
@@ -1,800 +1,822 @@
-:root {
+:root,:host {
       /* Default line-height for your application. */
       --sds-g-line-height: 1.5;
-      --c360-g-line-height: var(--sds-g-line-height);
+      --wes-g-line-height: var(--sds-g-line-height);
       /* Scaled font-size that is 10 stops bigger than the base. */
       --sds-g-font-scale-10: 3.247rem;
       /* Neutral 20 */
       --sds-g-color-palette-neutral-20: #2e2e2e;
-      --c360-g-color-palette-neutral-20: var(--sds-g-color-palette-neutral-20);
+      --wes-g-color-palette-neutral-20: var(--sds-g-color-palette-neutral-20);
       /* Orange 30 */
       --sds-g-color-palette-orange-30: #5f3e02;
-      --c360-g-color-palette-orange-30: var(--sds-g-color-palette-orange-30);
+      --wes-g-color-palette-orange-30: var(--sds-g-color-palette-orange-30);
       /* Green 60 */
       --sds-g-color-palette-green-60: #3ba755;
-      --c360-g-color-palette-green-60: var(--sds-g-color-palette-green-60);
+      --wes-g-color-palette-green-60: var(--sds-g-color-palette-green-60);
       /* Hot Orange 30 */
       --sds-g-color-palette-hot-orange-30: #7e2600;
-      --c360-g-color-palette-hot-orange-30: var(--sds-g-color-palette-hot-orange-30);
+      --wes-g-color-palette-hot-orange-30: var(--sds-g-color-palette-hot-orange-30);
       /* Border size 2. */
       --sds-g-sizing-border-2: 2px;
-      --c360-g-sizing-border-2: var(--sds-g-sizing-border-2);
+      --wes-g-sizing-border-2: var(--sds-g-sizing-border-2);
       /* Neutral 10 */
       --sds-g-color-palette-neutral-10: #181818;
-      --c360-g-color-palette-neutral-10: var(--sds-g-color-palette-neutral-10);
+      --wes-g-color-palette-neutral-10: var(--sds-g-color-palette-neutral-10);
       /* Yellow 15 */
       --sds-g-color-palette-yellow-15: #2e2204;
-      --c360-g-color-palette-yellow-15: var(--sds-g-color-palette-yellow-15);
+      --wes-g-color-palette-yellow-15: var(--sds-g-color-palette-yellow-15);
       /* Orange 20 */
       --sds-g-color-palette-orange-20: #3e2b02;
-      --c360-g-color-palette-orange-20: var(--sds-g-color-palette-orange-20);
+      --wes-g-color-palette-orange-20: var(--sds-g-color-palette-orange-20);
       /* Neutral 65 */
       --sds-g-color-palette-neutral-65: #a0a0a0;
-      --c360-g-color-palette-neutral-65: var(--sds-g-color-palette-neutral-65);
+      --wes-g-color-palette-neutral-65: var(--sds-g-color-palette-neutral-65);
       /* Green 50 */
       --sds-g-color-palette-green-50: #2e844a;
-      --c360-g-color-palette-green-50: var(--sds-g-color-palette-green-50);
+      --wes-g-color-palette-green-50: var(--sds-g-color-palette-green-50);
       /* Hot Orange 20 */
       --sds-g-color-palette-hot-orange-20: #541d01;
-      --c360-g-color-palette-hot-orange-20: var(--sds-g-color-palette-hot-orange-20);
+      --wes-g-color-palette-hot-orange-20: var(--sds-g-color-palette-hot-orange-20);
       /* Orange 10 */
       --sds-g-color-palette-orange-10: #201600;
-      --c360-g-color-palette-orange-10: var(--sds-g-color-palette-orange-10);
+      --wes-g-color-palette-orange-10: var(--sds-g-color-palette-orange-10);
       /* Green 40 */
       --sds-g-color-palette-green-40: #22683e;
-      --c360-g-color-palette-green-40: var(--sds-g-color-palette-green-40);
+      --wes-g-color-palette-green-40: var(--sds-g-color-palette-green-40);
       /* Hot Orange 10 */
       --sds-g-color-palette-hot-orange-10: #281202;
-      --c360-g-color-palette-hot-orange-10: var(--sds-g-color-palette-hot-orange-10);
+      --wes-g-color-palette-hot-orange-10: var(--sds-g-color-palette-hot-orange-10);
       /* Orange 65 */
       --sds-g-color-palette-orange-65: #f38303;
-      --c360-g-color-palette-orange-65: var(--sds-g-color-palette-orange-65);
+      --wes-g-color-palette-orange-65: var(--sds-g-color-palette-orange-65);
       /* Green 95 */
       --sds-g-color-palette-green-95: #ebf7e6;
-      --c360-g-color-palette-green-95: var(--sds-g-color-palette-green-95);
+      --wes-g-color-palette-green-95: var(--sds-g-color-palette-green-95);
       /* Hot Orange 65 */
       --sds-g-color-palette-hot-orange-65: #ff784f;
-      --c360-g-color-palette-hot-orange-65: var(--sds-g-color-palette-hot-orange-65);
+      --wes-g-color-palette-hot-orange-65: var(--sds-g-color-palette-hot-orange-65);
       /* System font stack for your application. */
       --sds-g-font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-      --c360-g-font-family: var(--sds-g-font-family);
+      --wes-g-font-family: var(--sds-g-font-family);
       /* Green 30 */
       --sds-g-color-palette-green-30: #194e31;
-      --c360-g-color-palette-green-30: var(--sds-g-color-palette-green-30);
+      --wes-g-color-palette-green-30: var(--sds-g-color-palette-green-30);
       /* Cloud Blue 15 */
       --sds-g-color-palette-cloud-blue-15: #0a2636;
-      --c360-g-color-palette-cloud-blue-15: var(--sds-g-color-palette-cloud-blue-15);
+      --wes-g-color-palette-cloud-blue-15: var(--sds-g-color-palette-cloud-blue-15);
       /* Indigo 15 */
       --sds-g-color-palette-indigo-15: #1f0974;
-      --c360-g-color-palette-indigo-15: var(--sds-g-color-palette-indigo-15);
+      --wes-g-color-palette-indigo-15: var(--sds-g-color-palette-indigo-15);
       /* Default color on active for hyperlinks. */
       --sds-g-link-color-active: #032d60;
-      --c360-g-link-color-active: var(--sds-g-link-color-active);
+      --wes-g-link-color-active: var(--sds-g-link-color-active);
       /* Neutral Inverse 1 - if used as a background, please use Neutral Inverse Contrast 1-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-inverse-1: #181818;
-      --c360-g-color-neutral-inverse-1: var(--sds-g-color-neutral-inverse-1);
+      --wes-g-color-neutral-inverse-1: var(--sds-g-color-neutral-inverse-1);
       /* Green 20 */
       --sds-g-color-palette-green-20: #0e3522;
-      --c360-g-color-palette-green-20: var(--sds-g-color-palette-green-20);
+      --wes-g-color-palette-green-20: var(--sds-g-color-palette-green-20);
       /* Error Base 1 - if used as a background, please use Error Base Contrast 1-4 to meet accessibility guidelines. */
       --sds-g-color-error-base-1: #ffffff;
-      --c360-g-color-error-base-1: var(--sds-g-color-error-base-1);
+      --wes-g-color-error-base-1: var(--sds-g-color-error-base-1);
       /* Shadow depth 1 */
-      --sds-g-shadow-1: 0 0 2px 0 #18181814, 0 2px 4px 1px #18181828;
-      --c360-g-shadow-1: var(--sds-g-shadow-1);
+      --sds-g-shadow-1: 0 0 2px 0 #18181808, 0 2px 4px 1px #18181816;
+      --wes-g-shadow-1: var(--sds-g-shadow-1);
       /* Brand Inverse 1 - if used as a background, please use Brand Inverse Contrast 1-4 to meet accessibility guidelines. */
       --sds-g-color-brand-inverse-1: #001639;
-      --c360-g-color-brand-inverse-1: var(--sds-g-color-brand-inverse-1);
+      --wes-g-color-brand-inverse-1: var(--sds-g-color-brand-inverse-1);
       /* Neutral Inverse 2 - if used as a background, please use Neutral Inverse Contrast 2-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-inverse-2: #2e2e30;
-      --c360-g-color-neutral-inverse-2: var(--sds-g-color-neutral-inverse-2);
+      --wes-g-color-neutral-inverse-2: var(--sds-g-color-neutral-inverse-2);
       /* Green 10 */
       --sds-g-color-palette-green-10: #071b12;
-      --c360-g-color-palette-green-10: var(--sds-g-color-palette-green-10);
+      --wes-g-color-palette-green-10: var(--sds-g-color-palette-green-10);
       /* Error Base 2 - if used as a background, please use Error Base Contrast 2-4 to meet accessibility guidelines. */
       --sds-g-color-error-base-2: #fef1ee;
-      --c360-g-color-error-base-2: var(--sds-g-color-error-base-2);
+      --wes-g-color-error-base-2: var(--sds-g-color-error-base-2);
       /* Green 65 */
       --sds-g-color-palette-green-65: #41b658;
-      --c360-g-color-palette-green-65: var(--sds-g-color-palette-green-65);
+      --wes-g-color-palette-green-65: var(--sds-g-color-palette-green-65);
       /* Neutral Base 1 - if used as a background, please use Neutral Base Contrast 1-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-base-1: #ffffff;
-      --c360-g-color-neutral-base-1: var(--sds-g-color-neutral-base-1);
+      --wes-g-color-neutral-base-1: var(--sds-g-color-neutral-base-1);
       /* Shadow depth 2 */
-      --sds-g-shadow-2: 0 2px 8px -2px #18181814, 0 8px 12px -2px #18181828;
-      --c360-g-shadow-2: var(--sds-g-shadow-2);
+      --sds-g-shadow-2: 0 2px 8px -2px #18181808, 0 8px 12px -2px #18181816;
+      --wes-g-shadow-2: var(--sds-g-shadow-2);
       /* Brand Base 1 - if used as a background, please use Brand Base Contrast 1-4 to meet accessibility guidelines. */
       --sds-g-color-brand-base-1: #ffffff;
-      --c360-g-color-brand-base-1: var(--sds-g-color-brand-base-1);
+      --wes-g-color-brand-base-1: var(--sds-g-color-brand-base-1);
       /* Brand Inverse 2 - if used as a background, please use Brand Inverse Contrast 2-4 to meet accessibility guidelines. */
       --sds-g-color-brand-inverse-2: #032d60;
-      --c360-g-color-brand-inverse-2: var(--sds-g-color-brand-inverse-2);
+      --wes-g-color-brand-inverse-2: var(--sds-g-color-brand-inverse-2);
       /* Neutral Inverse 3 - if used as a background, please use Neutral Inverse Contrast 3-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-inverse-3: #444447;
-      --c360-g-color-neutral-inverse-3: var(--sds-g-color-neutral-inverse-3);
+      --wes-g-color-neutral-inverse-3: var(--sds-g-color-neutral-inverse-3);
       /* Neutral 15 */
       --sds-g-color-palette-neutral-15: #242424;
-      --c360-g-color-palette-neutral-15: var(--sds-g-color-palette-neutral-15);
+      --wes-g-color-palette-neutral-15: var(--sds-g-color-palette-neutral-15);
       /* Error Base 3 - if used as a background, please use Error Base Contrast 3-4 to meet accessibility guidelines. */
       --sds-g-color-error-base-3: #feded8;
-      --c360-g-color-error-base-3: var(--sds-g-color-error-base-3);
+      --wes-g-color-error-base-3: var(--sds-g-color-error-base-3);
       /* Neutral Base 2 - if used as a background, please use Neutral Base Contrast 2-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-base-2: #f3f3f3;
-      --c360-g-color-neutral-base-2: var(--sds-g-color-neutral-base-2);
+      --wes-g-color-neutral-base-2: var(--sds-g-color-neutral-base-2);
       /* Shadow depth 3 */
-      --sds-g-shadow-3: 0 12px 24px -4px #18181814, 0 16px 32px -4px #18181828;
-      --c360-g-shadow-3: var(--sds-g-shadow-3);
+      --sds-g-shadow-3: 0 12px 24px -4px #18181808, 0 16px 32px -4px #18181816;
+      --wes-g-shadow-3: var(--sds-g-shadow-3);
       /* Brand Base 2 - if used as a background, please use Brand Base Contrast 2-4 to meet accessibility guidelines. */
       --sds-g-color-brand-base-2: #eef4ff;
-      --c360-g-color-brand-base-2: var(--sds-g-color-brand-base-2);
+      --wes-g-color-brand-base-2: var(--sds-g-color-brand-base-2);
       /* Brand Inverse 3 - if used as a background, please use Brand Inverse Contrast 3-4 to meet accessibility guidelines. */
       --sds-g-color-brand-inverse-3: #014486;
-      --c360-g-color-brand-inverse-3: var(--sds-g-color-brand-inverse-3);
+      --wes-g-color-brand-inverse-3: var(--sds-g-color-brand-inverse-3);
       /* Warning Base Contrast 1 - if used as a background, please use Warning Base Base 1-4 to meet accessibility guidelines. */
       --sds-g-color-warning-base-contrast-1: #a86403;
-      --c360-g-color-warning-base-contrast-1: var(--sds-g-color-warning-base-contrast-1);
+      --wes-g-color-warning-base-contrast-1: var(--sds-g-color-warning-base-contrast-1);
       /* Neutral Inverse 4 - if used as a background, please use Neutral Inverse Contrast 4 to meet accessibility guidelines. */
       --sds-g-color-neutral-inverse-4: #5a5c61;
-      --c360-g-color-neutral-inverse-4: var(--sds-g-color-neutral-inverse-4);
+      --wes-g-color-neutral-inverse-4: var(--sds-g-color-neutral-inverse-4);
       /* Spacing size 1. */
       --sds-g-spacing-1: 0.25rem;
-      --c360-g-spacing-1: var(--sds-g-spacing-1);
+      --wes-g-spacing-1: var(--sds-g-spacing-1);
       /* Orange 15 */
       --sds-g-color-palette-orange-15: #371e03;
-      --c360-g-color-palette-orange-15: var(--sds-g-color-palette-orange-15);
+      --wes-g-color-palette-orange-15: var(--sds-g-color-palette-orange-15);
       /* Error Base 4 - if used as a background, please use Error Base Contrast 4 to meet accessibility guidelines. */
       --sds-g-color-error-base-4: #feb8ab;
-      --c360-g-color-error-base-4: var(--sds-g-color-error-base-4);
+      --wes-g-color-error-base-4: var(--sds-g-color-error-base-4);
       /* Hot Orange 15 */
       --sds-g-color-palette-hot-orange-15: #421604;
-      --c360-g-color-palette-hot-orange-15: var(--sds-g-color-palette-hot-orange-15);
+      --wes-g-color-palette-hot-orange-15: var(--sds-g-color-palette-hot-orange-15);
       /* Neutral Base 3 - if used as a background, please use Neutral Base Contrast 3-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-base-3: #e5e5e5;
-      --c360-g-color-neutral-base-3: var(--sds-g-color-neutral-base-3);
+      --wes-g-color-neutral-base-3: var(--sds-g-color-neutral-base-3);
       /* Shadow depth 4 */
-      --sds-g-shadow-4: 0 24px 48px -4px #18181833;
-      --c360-g-shadow-4: var(--sds-g-shadow-4);
+      --sds-g-shadow-4: 0 24px 48px -2px #18181820;
+      --wes-g-shadow-4: var(--sds-g-shadow-4);
       /* Brand Base 3 - if used as a background, please use Brand Base Contrast 3-4 to meet accessibility guidelines. */
       --sds-g-color-brand-base-3: #d8e6fe;
-      --c360-g-color-brand-base-3: var(--sds-g-color-brand-base-3);
+      --wes-g-color-brand-base-3: var(--sds-g-color-brand-base-3);
       /* Brand Inverse 4 - if used as a background, please use Brand Inverse Contrast 4 to meet accessibility guidelines. */
       --sds-g-color-brand-inverse-4: #0b5cab;
-      --c360-g-color-brand-inverse-4: var(--sds-g-color-brand-inverse-4);
+      --wes-g-color-brand-inverse-4: var(--sds-g-color-brand-inverse-4);
       /* Warning Base Contrast 2 - if used as a background, please use Warning Base Base 2-4 to meet accessibility guidelines. */
       --sds-g-color-warning-base-contrast-2: #8c4b02;
-      --c360-g-color-warning-base-contrast-2: var(--sds-g-color-warning-base-contrast-2);
+      --wes-g-color-warning-base-contrast-2: var(--sds-g-color-warning-base-contrast-2);
       /* Spacing size 2. */
       --sds-g-spacing-2: 0.5rem;
-      --c360-g-spacing-2: var(--sds-g-spacing-2);
+      --wes-g-spacing-2: var(--sds-g-spacing-2);
       /* Neutral Base 4 - if used as a background, please use Neutral Base Contrast 4 to meet accessibility guidelines. */
       --sds-g-color-neutral-base-4: #c9c9cb;
-      --c360-g-color-neutral-base-4: var(--sds-g-color-neutral-base-4);
+      --wes-g-color-neutral-base-4: var(--sds-g-color-neutral-base-4);
       /* Brand Base 4 - if used as a background, please use Brand Base Contrast 4 to meet accessibility guidelines. */
       --sds-g-color-brand-base-4: #aacbff;
-      --c360-g-color-brand-base-4: var(--sds-g-color-brand-base-4);
+      --wes-g-color-brand-base-4: var(--sds-g-color-brand-base-4);
       /* Default line-height for your application. */
       --sds-g-font-leading: 1.5;
-      --c360-g-font-leading: var(--sds-g-font-leading);
+      --wes-g-font-leading: var(--sds-g-font-leading);
       /* Warning Base Contrast 3 - if used as a background, please use Warning Base Base 3-4 to meet accessibility guidelines. */
       --sds-g-color-warning-base-contrast-3: #6f3400;
-      --c360-g-color-warning-base-contrast-3: var(--sds-g-color-warning-base-contrast-3);
+      --wes-g-color-warning-base-contrast-3: var(--sds-g-color-warning-base-contrast-3);
       /* Success Base 1 - if used as a background, please use Success Base Contrast 1-4 to meet accessibility guidelines. */
       --sds-g-color-success-base-1: #ffffff;
-      --c360-g-color-success-base-1: var(--sds-g-color-success-base-1);
+      --wes-g-color-success-base-1: var(--sds-g-color-success-base-1);
       /* Spacing size 3. */
       --sds-g-spacing-3: 0.75rem;
-      --c360-g-spacing-3: var(--sds-g-spacing-3);
+      --wes-g-spacing-3: var(--sds-g-spacing-3);
       /* Violet 90 */
       --sds-g-color-palette-violet-90: #f2defe;
-      --c360-g-color-palette-violet-90: var(--sds-g-color-palette-violet-90);
+      --wes-g-color-palette-violet-90: var(--sds-g-color-palette-violet-90);
       /* Spacing size 10. */
       --sds-g-spacing-10: 4rem;
-      --c360-g-spacing-10: var(--sds-g-spacing-10);
+      --wes-g-spacing-10: var(--sds-g-spacing-10);
       /* Warning Base Contrast 4 - if used as a background, please use Warning Base Base 4 to meet accessibility guidelines. */
       --sds-g-color-warning-base-contrast-4: #4f2100;
-      --c360-g-color-warning-base-contrast-4: var(--sds-g-color-warning-base-contrast-4);
+      --wes-g-color-warning-base-contrast-4: var(--sds-g-color-warning-base-contrast-4);
       /* Success Base 2 - if used as a background, please use Success Base Contrast 2-4 to meet accessibility guidelines. */
       --sds-g-color-success-base-2: #ebf7e6;
-      --c360-g-color-success-base-2: var(--sds-g-color-success-base-2);
+      --wes-g-color-success-base-2: var(--sds-g-color-success-base-2);
       /* Spacing size 4. */
       --sds-g-spacing-4: 1rem;
-      --c360-g-spacing-4: var(--sds-g-spacing-4);
+      --wes-g-spacing-4: var(--sds-g-spacing-4);
       /* Green 15 */
       --sds-g-color-palette-green-15: #0c2912;
-      --c360-g-color-palette-green-15: var(--sds-g-color-palette-green-15);
+      --wes-g-color-palette-green-15: var(--sds-g-color-palette-green-15);
       /* Violet 80 */
       --sds-g-color-palette-violet-80: #e5b9fe;
-      --c360-g-color-palette-violet-80: var(--sds-g-color-palette-violet-80);
+      --wes-g-color-palette-violet-80: var(--sds-g-color-palette-violet-80);
       /* Spacing size 11. */
       --sds-g-spacing-11: 4.5rem;
-      --c360-g-spacing-11: var(--sds-g-spacing-11);
+      --wes-g-spacing-11: var(--sds-g-spacing-11);
       /* Success Base 3 - if used as a background, please use Success Base Contrast 3-4 to meet accessibility guidelines. */
       --sds-g-color-success-base-3: #cdefc4;
-      --c360-g-color-success-base-3: var(--sds-g-color-success-base-3);
+      --wes-g-color-success-base-3: var(--sds-g-color-success-base-3);
       /* Spacing size 5. */
       --sds-g-spacing-5: 1.5rem;
-      --c360-g-spacing-5: var(--sds-g-spacing-5);
+      --wes-g-spacing-5: var(--sds-g-spacing-5);
       /* Small border radius for UI elements. */
       --sds-g-radius-border-1: 0.125rem;
-      --c360-g-radius-border-1: var(--sds-g-radius-border-1);
+      --wes-g-radius-border-1: var(--sds-g-radius-border-1);
       /* Violet 70 */
       --sds-g-color-palette-violet-70: #d892fe;
-      --c360-g-color-palette-violet-70: var(--sds-g-color-palette-violet-70);
+      --wes-g-color-palette-violet-70: var(--sds-g-color-palette-violet-70);
       /* Spacing size 12. */
       --sds-g-spacing-12: 5rem;
-      --c360-g-spacing-12: var(--sds-g-spacing-12);
+      --wes-g-spacing-12: var(--sds-g-spacing-12);
       /* Default border color for UI elements. */
       --sds-g-color-border-base-1: #aeaeae;
-      --c360-g-color-border-base-1: var(--sds-g-color-border-base-1);
+      --wes-g-color-border-base-1: var(--sds-g-color-border-base-1);
       /* Teal 90 */
       --sds-g-color-palette-teal-90: #acf3e4;
-      --c360-g-color-palette-teal-90: var(--sds-g-color-palette-teal-90);
+      --wes-g-color-palette-teal-90: var(--sds-g-color-palette-teal-90);
       /* Success Base 4 - if used as a background, please use Success Base Contrast 4 to meet accessibility guidelines. */
       --sds-g-color-success-base-4: #91db8b;
-      --c360-g-color-success-base-4: var(--sds-g-color-success-base-4);
+      --wes-g-color-success-base-4: var(--sds-g-color-success-base-4);
       /* Spacing size 6. */
       --sds-g-spacing-6: 2rem;
-      --c360-g-spacing-6: var(--sds-g-spacing-6);
+      --wes-g-spacing-6: var(--sds-g-spacing-6);
       /* Medium border radius for UI elements. */
       --sds-g-radius-border-2: 0.25rem;
-      --c360-g-radius-border-2: var(--sds-g-radius-border-2);
+      --wes-g-radius-border-2: var(--sds-g-radius-border-2);
       /* Purple 90 */
       --sds-g-color-palette-purple-90: #ece1f9;
-      --c360-g-color-palette-purple-90: var(--sds-g-color-palette-purple-90);
+      --wes-g-color-palette-purple-90: var(--sds-g-color-palette-purple-90);
       /* Violet 60 */
       --sds-g-color-palette-violet-60: #cb65ff;
-      --c360-g-color-palette-violet-60: var(--sds-g-color-palette-violet-60);
+      --wes-g-color-palette-violet-60: var(--sds-g-color-palette-violet-60);
       /* Alternate border color for UI elements. */
       --sds-g-color-border-base-2: #939393;
-      --c360-g-color-border-base-2: var(--sds-g-color-border-base-2);
+      --wes-g-color-border-base-2: var(--sds-g-color-border-base-2);
       /* Teal 80 */
       --sds-g-color-palette-teal-80: #04e1cb;
-      --c360-g-color-palette-teal-80: var(--sds-g-color-palette-teal-80);
+      --wes-g-color-palette-teal-80: var(--sds-g-color-palette-teal-80);
       /* Spacing size 7. */
       --sds-g-spacing-7: 2.5rem;
-      --c360-g-spacing-7: var(--sds-g-spacing-7);
+      --wes-g-spacing-7: var(--sds-g-spacing-7);
       /* Large border radius for UI elements. */
       --sds-g-radius-border-3: 0.5rem;
-      --c360-g-radius-border-3: var(--sds-g-radius-border-3);
+      --wes-g-radius-border-3: var(--sds-g-radius-border-3);
       /* Purple 80 */
       --sds-g-color-palette-purple-80: #d78ff5;
-      --c360-g-color-palette-purple-80: var(--sds-g-color-palette-purple-80);
+      --wes-g-color-palette-purple-80: var(--sds-g-color-palette-purple-80);
       /* Violet 50 */
       --sds-g-color-palette-violet-50: #ba01ff;
-      --c360-g-color-palette-violet-50: var(--sds-g-color-palette-violet-50);
+      --wes-g-color-palette-violet-50: var(--sds-g-color-palette-violet-50);
       /* Teal 70 */
       --sds-g-color-palette-teal-70: #01c3b3;
-      --c360-g-color-palette-teal-70: var(--sds-g-color-palette-teal-70);
+      --wes-g-color-palette-teal-70: var(--sds-g-color-palette-teal-70);
       /* Spacing size 8. */
       --sds-g-spacing-8: 3rem;
-      --c360-g-spacing-8: var(--sds-g-spacing-8);
+      --wes-g-spacing-8: var(--sds-g-spacing-8);
       /* Extra Large border radius for UI elements. */
       --sds-g-radius-border-4: 1rem;
-      --c360-g-radius-border-4: var(--sds-g-radius-border-4);
+      --wes-g-radius-border-4: var(--sds-g-radius-border-4);
       /* Blue 90 */
       --sds-g-color-palette-blue-90: #d8e6fe;
-      --c360-g-color-palette-blue-90: var(--sds-g-color-palette-blue-90);
+      --wes-g-color-palette-blue-90: var(--sds-g-color-palette-blue-90);
       /* Purple 70 */
       --sds-g-color-palette-purple-70: #c29ef1;
-      --c360-g-color-palette-purple-70: var(--sds-g-color-palette-purple-70);
+      --wes-g-color-palette-purple-70: var(--sds-g-color-palette-purple-70);
       /* Violet 40 */
       --sds-g-color-palette-violet-40: #9602c7;
-      --c360-g-color-palette-violet-40: var(--sds-g-color-palette-violet-40);
+      --wes-g-color-palette-violet-40: var(--sds-g-color-palette-violet-40);
       /* Violet 95 */
       --sds-g-color-palette-violet-95: #f9f0ff;
-      --c360-g-color-palette-violet-95: var(--sds-g-color-palette-violet-95);
+      --wes-g-color-palette-violet-95: var(--sds-g-color-palette-violet-95);
       /* Success Base Contrast 1 - if used as a background, please use Success Base Base 1-4 to meet accessibility guidelines. */
       --sds-g-color-success-base-contrast-1: #2e844a;
-      --c360-g-color-success-base-contrast-1: var(--sds-g-color-success-base-contrast-1);
+      --wes-g-color-success-base-contrast-1: var(--sds-g-color-success-base-contrast-1);
       /* Teal 60 */
       --sds-g-color-palette-teal-60: #06a59a;
-      --c360-g-color-palette-teal-60: var(--sds-g-color-palette-teal-60);
+      --wes-g-color-palette-teal-60: var(--sds-g-color-palette-teal-60);
       /* Red 90 */
       --sds-g-color-palette-red-90: #feded8;
-      --c360-g-color-palette-red-90: var(--sds-g-color-palette-red-90);
+      --wes-g-color-palette-red-90: var(--sds-g-color-palette-red-90);
       /* Spacing size 9. */
       --sds-g-spacing-9: 3.5rem;
-      --c360-g-spacing-9: var(--sds-g-spacing-9);
+      --wes-g-spacing-9: var(--sds-g-spacing-9);
       /* Blue 80 */
       --sds-g-color-palette-blue-80: #aacbff;
-      --c360-g-color-palette-blue-80: var(--sds-g-color-palette-blue-80);
+      --wes-g-color-palette-blue-80: var(--sds-g-color-palette-blue-80);
       /* Purple 60 */
       --sds-g-color-palette-purple-60: #ad7bee;
-      --c360-g-color-palette-purple-60: var(--sds-g-color-palette-purple-60);
+      --wes-g-color-palette-purple-60: var(--sds-g-color-palette-purple-60);
       /* Violet 30 */
       --sds-g-color-palette-violet-30: #730394;
-      --c360-g-color-palette-violet-30: var(--sds-g-color-palette-violet-30);
+      --wes-g-color-palette-violet-30: var(--sds-g-color-palette-violet-30);
       /* Success Base Contrast 2 - if used as a background, please use Success Base Base 2-4 to meet accessibility guidelines. */
       --sds-g-color-success-base-contrast-2: #22683e;
-      --c360-g-color-success-base-contrast-2: var(--sds-g-color-success-base-contrast-2);
+      --wes-g-color-success-base-contrast-2: var(--sds-g-color-success-base-contrast-2);
       /* Scaled font-size that is 1 stop bigger than the base. */
       --sds-g-font-scale-1: 1.125rem;
       /* Red 80 */
       --sds-g-color-palette-red-80: #feb8ab;
-      --c360-g-color-palette-red-80: var(--sds-g-color-palette-red-80);
+      --wes-g-color-palette-red-80: var(--sds-g-color-palette-red-80);
       /* Blue 70 */
       --sds-g-color-palette-blue-70: #78b0fd;
-      --c360-g-color-palette-blue-70: var(--sds-g-color-palette-blue-70);
+      --wes-g-color-palette-blue-70: var(--sds-g-color-palette-blue-70);
       /* Purple 50 */
       --sds-g-color-palette-purple-50: #9050e9;
-      --c360-g-color-palette-purple-50: var(--sds-g-color-palette-purple-50);
+      --wes-g-color-palette-purple-50: var(--sds-g-color-palette-purple-50);
       /* Violet 20 */
       --sds-g-color-palette-violet-20: #520066;
-      --c360-g-color-palette-violet-20: var(--sds-g-color-palette-violet-20);
+      --wes-g-color-palette-violet-20: var(--sds-g-color-palette-violet-20);
       /* Success Base Contrast 3 - if used as a background, please use Success Base Base 3-4 to meet accessibility guidelines. */
       --sds-g-color-success-base-contrast-3: #194e31;
-      --c360-g-color-success-base-contrast-3: var(--sds-g-color-success-base-contrast-3);
+      --wes-g-color-success-base-contrast-3: var(--sds-g-color-success-base-contrast-3);
       /* Warning Base 1 - if used as a background, please use Warning Base Contrast 1-4 to meet accessibility guidelines. */
       --sds-g-color-warning-base-1: #ffffff;
-      --c360-g-color-warning-base-1: var(--sds-g-color-warning-base-1);
+      --wes-g-color-warning-base-1: var(--sds-g-color-warning-base-1);
       /* Default color for hyperlinks. */
       --sds-g-link-color: #0b5cab;
-      --c360-g-link-color: var(--sds-g-link-color);
+      --wes-g-link-color: var(--sds-g-link-color);
       /* Teal 50 */
       --sds-g-color-palette-teal-50: #0b827c;
-      --c360-g-color-palette-teal-50: var(--sds-g-color-palette-teal-50);
+      --wes-g-color-palette-teal-50: var(--sds-g-color-palette-teal-50);
       /* Teal 95 */
       --sds-g-color-palette-teal-95: #def9f3;
-      --c360-g-color-palette-teal-95: var(--sds-g-color-palette-teal-95);
+      --wes-g-color-palette-teal-95: var(--sds-g-color-palette-teal-95);
       /* Red 70 */
       --sds-g-color-palette-red-70: #fe8f7d;
-      --c360-g-color-palette-red-70: var(--sds-g-color-palette-red-70);
+      --wes-g-color-palette-red-70: var(--sds-g-color-palette-red-70);
       /* Scaled font-size that is 2 stops bigger than the base. */
       --sds-g-font-scale-2: 1.266rem;
       /* Blue 60 */
       --sds-g-color-palette-blue-60: #1b96ff;
-      --c360-g-color-palette-blue-60: var(--sds-g-color-palette-blue-60);
+      --wes-g-color-palette-blue-60: var(--sds-g-color-palette-blue-60);
       /* Purple 40 */
       --sds-g-color-palette-purple-40: #7526e3;
-      --c360-g-color-palette-purple-40: var(--sds-g-color-palette-purple-40);
+      --wes-g-color-palette-purple-40: var(--sds-g-color-palette-purple-40);
       /* Violet 10 */
       --sds-g-color-palette-violet-10: #2e0039;
-      --c360-g-color-palette-violet-10: var(--sds-g-color-palette-violet-10);
+      --wes-g-color-palette-violet-10: var(--sds-g-color-palette-violet-10);
       /* Purple 95 */
       --sds-g-color-palette-purple-95: #f6f2fb;
-      --c360-g-color-palette-purple-95: var(--sds-g-color-palette-purple-95);
+      --wes-g-color-palette-purple-95: var(--sds-g-color-palette-purple-95);
       /* Violet 65 */
       --sds-g-color-palette-violet-65: #d17dfe;
-      --c360-g-color-palette-violet-65: var(--sds-g-color-palette-violet-65);
+      --wes-g-color-palette-violet-65: var(--sds-g-color-palette-violet-65);
       /* Success Base Contrast 4 - if used as a background, please use Success Base Base 4 to meet accessibility guidelines. */
       --sds-g-color-success-base-contrast-4: #0e3522;
-      --c360-g-color-success-base-contrast-4: var(--sds-g-color-success-base-contrast-4);
+      --wes-g-color-success-base-contrast-4: var(--sds-g-color-success-base-contrast-4);
       /* Warning Base 2 - if used as a background, please use Warning Base Contrast 2-4 to meet accessibility guidelines. */
       --sds-g-color-warning-base-2: #fbf3e0;
-      --c360-g-color-warning-base-2: var(--sds-g-color-warning-base-2);
+      --wes-g-color-warning-base-2: var(--sds-g-color-warning-base-2);
       /* Teal 40 */
       --sds-g-color-palette-teal-40: #056764;
-      --c360-g-color-palette-teal-40: var(--sds-g-color-palette-teal-40);
+      --wes-g-color-palette-teal-40: var(--sds-g-color-palette-teal-40);
       /* Neutral Base Contrast 1 - if used as a background, please use Neutral Base 1-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-base-contrast-1: #929398;
-      --c360-g-color-neutral-base-contrast-1: var(--sds-g-color-neutral-base-contrast-1);
+      --wes-g-color-neutral-base-contrast-1: var(--sds-g-color-neutral-base-contrast-1);
       /* Red 60 */
       --sds-g-color-palette-red-60: #fe5c4c;
-      --c360-g-color-palette-red-60: var(--sds-g-color-palette-red-60);
+      --wes-g-color-palette-red-60: var(--sds-g-color-palette-red-60);
       /* Scaled font-size that is 3 stops bigger than the base. */
       --sds-g-font-scale-3: 1.424rem;
       /* Blue 50 */
       --sds-g-color-palette-blue-50: #0176d3;
-      --c360-g-color-palette-blue-50: var(--sds-g-color-palette-blue-50);
+      --wes-g-color-palette-blue-50: var(--sds-g-color-palette-blue-50);
       /* Purple 30 */
       --sds-g-color-palette-purple-30: #5a1ba9;
-      --c360-g-color-palette-purple-30: var(--sds-g-color-palette-purple-30);
+      --wes-g-color-palette-purple-30: var(--sds-g-color-palette-purple-30);
       /* Pink 90 */
       --sds-g-color-palette-pink-90: #fddde3;
-      --c360-g-color-palette-pink-90: var(--sds-g-color-palette-pink-90);
+      --wes-g-color-palette-pink-90: var(--sds-g-color-palette-pink-90);
       /* Warning Base 3 - if used as a background, please use Warning Base Contrast 3-4 to meet accessibility guidelines. */
       --sds-g-color-warning-base-3: #f9e3b6;
-      --c360-g-color-warning-base-3: var(--sds-g-color-warning-base-3);
+      --wes-g-color-warning-base-3: var(--sds-g-color-warning-base-3);
       /* Brand Base Contrast 1 - if used as a background, please use Brand Base 1-4 to meet accessibility guidelines. */
       --sds-g-color-brand-base-contrast-1: #1b96ff;
-      --c360-g-color-brand-base-contrast-1: var(--sds-g-color-brand-base-contrast-1);
+      --wes-g-color-brand-base-contrast-1: var(--sds-g-color-brand-base-contrast-1);
       /* Teal 30 */
       --sds-g-color-palette-teal-30: #024d4c;
-      --c360-g-color-palette-teal-30: var(--sds-g-color-palette-teal-30);
+      --wes-g-color-palette-teal-30: var(--sds-g-color-palette-teal-30);
       /* Neutral Base Contrast 2 - if used as a background, please use Neutral Base 2-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-base-contrast-2: #737479;
-      --c360-g-color-neutral-base-contrast-2: var(--sds-g-color-neutral-base-contrast-2);
+      --wes-g-color-neutral-base-contrast-2: var(--sds-g-color-neutral-base-contrast-2);
       /* Scaled font-size that is 1 stop smaller than the base. */
       --sds-g-font-scale-neg-1: 0.875rem;
       /* Red 50 */
       --sds-g-color-palette-red-50: #ea001e;
-      --c360-g-color-palette-red-50: var(--sds-g-color-palette-red-50);
+      --wes-g-color-palette-red-50: var(--sds-g-color-palette-red-50);
       /* Scaled font-size that is 4 stops bigger than the base. */
       --sds-g-font-scale-4: 1.602rem;
       /* Blue 40 */
       --sds-g-color-palette-blue-40: #0b5cab;
-      --c360-g-color-palette-blue-40: var(--sds-g-color-palette-blue-40);
+      --wes-g-color-palette-blue-40: var(--sds-g-color-palette-blue-40);
       /* Purple 20 */
       --sds-g-color-palette-purple-20: #401075;
-      --c360-g-color-palette-purple-20: var(--sds-g-color-palette-purple-20);
+      --wes-g-color-palette-purple-20: var(--sds-g-color-palette-purple-20);
       /* Neutral Inverse Contrast 1 - if used as a background, please use Neutral Inverse Base 1-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-inverse-contrast-1: #737479;
-      --c360-g-color-neutral-inverse-contrast-1: var(--sds-g-color-neutral-inverse-contrast-1);
+      --wes-g-color-neutral-inverse-contrast-1: var(--sds-g-color-neutral-inverse-contrast-1);
       /* Blue 95 */
       --sds-g-color-palette-blue-95: #eef4ff;
-      --c360-g-color-palette-blue-95: var(--sds-g-color-palette-blue-95);
+      --wes-g-color-palette-blue-95: var(--sds-g-color-palette-blue-95);
       /* Brand Inverse Contrast 1 - if used as a background, please use Brand Inverse Base 1-4 to meet accessibility guidelines. */
       --sds-g-color-brand-inverse-contrast-1: #0176d3;
-      --c360-g-color-brand-inverse-contrast-1: var(--sds-g-color-brand-inverse-contrast-1);
+      --wes-g-color-brand-inverse-contrast-1: var(--sds-g-color-brand-inverse-contrast-1);
       /* Pink 80 */
       --sds-g-color-palette-pink-80: #fdb6c5;
-      --c360-g-color-palette-pink-80: var(--sds-g-color-palette-pink-80);
+      --wes-g-color-palette-pink-80: var(--sds-g-color-palette-pink-80);
       /* Warning Base 4 - if used as a background, please use Warning Base Contrast 4 to meet accessibility guidelines. */
       --sds-g-color-warning-base-4: #fcc003;
-      --c360-g-color-warning-base-4: var(--sds-g-color-warning-base-4);
+      --wes-g-color-warning-base-4: var(--sds-g-color-warning-base-4);
       /* Brand Base Contrast 2 - if used as a background, please use Brand Base 2-4 to meet accessibility guidelines. */
       --sds-g-color-brand-base-contrast-2: #0176d3;
-      --c360-g-color-brand-base-contrast-2: var(--sds-g-color-brand-base-contrast-2);
+      --wes-g-color-brand-base-contrast-2: var(--sds-g-color-brand-base-contrast-2);
       /* Teal 20 */
       --sds-g-color-palette-teal-20: #023434;
-      --c360-g-color-palette-teal-20: var(--sds-g-color-palette-teal-20);
+      --wes-g-color-palette-teal-20: var(--sds-g-color-palette-teal-20);
       /* Error Base Contrast 1 - if used as a background, please use Error Base Base 1-4 to meet accessibility guidelines. */
       --sds-g-color-error-base-contrast-1: #ea001e;
-      --c360-g-color-error-base-contrast-1: var(--sds-g-color-error-base-contrast-1);
+      --wes-g-color-error-base-contrast-1: var(--sds-g-color-error-base-contrast-1);
       /* Teal 65 */
       --sds-g-color-palette-teal-65: #03b4a7;
-      --c360-g-color-palette-teal-65: var(--sds-g-color-palette-teal-65);
+      --wes-g-color-palette-teal-65: var(--sds-g-color-palette-teal-65);
       /* Neutral Base Contrast 3 - if used as a background, please use Neutral Base 3-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-base-contrast-3: #5a5c61;
-      --c360-g-color-neutral-base-contrast-3: var(--sds-g-color-neutral-base-contrast-3);
+      --wes-g-color-neutral-base-contrast-3: var(--sds-g-color-neutral-base-contrast-3);
       /* Scaled font-size that is 2 stops smaller than the base. */
       --sds-g-font-scale-neg-2: 0.8125rem;
       /* Red 40 */
       --sds-g-color-palette-red-40: #ba0517;
-      --c360-g-color-palette-red-40: var(--sds-g-color-palette-red-40);
+      --wes-g-color-palette-red-40: var(--sds-g-color-palette-red-40);
       /* Scaled font-size that is 5 stops bigger than the base. */
       --sds-g-font-scale-5: 1.802rem;
       /* Blue 30 */
       --sds-g-color-palette-blue-30: #014486;
-      --c360-g-color-palette-blue-30: var(--sds-g-color-palette-blue-30);
+      --wes-g-color-palette-blue-30: var(--sds-g-color-palette-blue-30);
       /* Purple 10 */
       --sds-g-color-palette-purple-10: #240643;
-      --c360-g-color-palette-purple-10: var(--sds-g-color-palette-purple-10);
+      --wes-g-color-palette-purple-10: var(--sds-g-color-palette-purple-10);
       /* Red 95 */
       --sds-g-color-palette-red-95: #fef1ee;
-      --c360-g-color-palette-red-95: var(--sds-g-color-palette-red-95);
+      --wes-g-color-palette-red-95: var(--sds-g-color-palette-red-95);
       /* Neutral Inverse Contrast 2 - if used as a background, please use Neutral Inverse Base 2-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-inverse-contrast-2: #929398;
-      --c360-g-color-neutral-inverse-contrast-2: var(--sds-g-color-neutral-inverse-contrast-2);
+      --wes-g-color-neutral-inverse-contrast-2: var(--sds-g-color-neutral-inverse-contrast-2);
       /* Purple 65 */
       --sds-g-color-palette-purple-65: #b78def;
-      --c360-g-color-palette-purple-65: var(--sds-g-color-palette-purple-65);
+      --wes-g-color-palette-purple-65: var(--sds-g-color-palette-purple-65);
       /* Brand Inverse Contrast 2 - if used as a background, please use Brand Inverse Base 2-4 to meet accessibility guidelines. */
       --sds-g-color-brand-inverse-contrast-2: #1b96ff;
-      --c360-g-color-brand-inverse-contrast-2: var(--sds-g-color-brand-inverse-contrast-2);
+      --wes-g-color-brand-inverse-contrast-2: var(--sds-g-color-brand-inverse-contrast-2);
       /* Yellow 90 */
       --sds-g-color-palette-yellow-90: #f9e3b6;
-      --c360-g-color-palette-yellow-90: var(--sds-g-color-palette-yellow-90);
+      --wes-g-color-palette-yellow-90: var(--sds-g-color-palette-yellow-90);
       /* Pink 70 */
       --sds-g-color-palette-pink-70: #fe8aa7;
-      --c360-g-color-palette-pink-70: var(--sds-g-color-palette-pink-70);
+      --wes-g-color-palette-pink-70: var(--sds-g-color-palette-pink-70);
       /* Teal 10 */
       --sds-g-color-palette-teal-10: #071b12;
-      --c360-g-color-palette-teal-10: var(--sds-g-color-palette-teal-10);
+      --wes-g-color-palette-teal-10: var(--sds-g-color-palette-teal-10);
       /* Brand Base Contrast 3 - if used as a background, please use Brand Base 3-4 to meet accessibility guidelines. */
       --sds-g-color-brand-base-contrast-3: #0b5cab;
-      --c360-g-color-brand-base-contrast-3: var(--sds-g-color-brand-base-contrast-3);
+      --wes-g-color-brand-base-contrast-3: var(--sds-g-color-brand-base-contrast-3);
       /* Error Base Contrast 2 - if used as a background, please use Error Base Base 2-4 to meet accessibility guidelines. */
       --sds-g-color-error-base-contrast-2: #ba0517;
-      --c360-g-color-error-base-contrast-2: var(--sds-g-color-error-base-contrast-2);
+      --wes-g-color-error-base-contrast-2: var(--sds-g-color-error-base-contrast-2);
       /* Neutral Base Contrast 4 - if used as a background, please use Neutral Base 4 to meet accessibility guidelines. */
       --sds-g-color-neutral-base-contrast-4: #181818;
-      --c360-g-color-neutral-base-contrast-4: var(--sds-g-color-neutral-base-contrast-4);
+      --wes-g-color-neutral-base-contrast-4: var(--sds-g-color-neutral-base-contrast-4);
       /* Red 30 */
       --sds-g-color-palette-red-30: #8e030f;
-      --c360-g-color-palette-red-30: var(--sds-g-color-palette-red-30);
+      --wes-g-color-palette-red-30: var(--sds-g-color-palette-red-30);
       /* Scaled font-size that is 3 stops smaller than the base. */
       --sds-g-font-scale-neg-3: 0.75rem;
       /* Blue 20 */
       --sds-g-color-palette-blue-20: #032d60;
-      --c360-g-color-palette-blue-20: var(--sds-g-color-palette-blue-20);
+      --wes-g-color-palette-blue-20: var(--sds-g-color-palette-blue-20);
       /* Scaled font-size that is 6 stops bigger than the base. */
       --sds-g-font-scale-6: 2.027rem;
       /* Neutral Inverse Contrast 3 - if used as a background, please use Neutral Inverse Base 3-4 to meet accessibility guidelines. */
       --sds-g-color-neutral-inverse-contrast-3: #adaeb1;
-      --c360-g-color-neutral-inverse-contrast-3: var(--sds-g-color-neutral-inverse-contrast-3);
+      --wes-g-color-neutral-inverse-contrast-3: var(--sds-g-color-neutral-inverse-contrast-3);
       /* Brand Inverse Contrast 3 - if used as a background, please use Brand Inverse Base 3-4 to meet accessibility guidelines. */
       --sds-g-color-brand-inverse-contrast-3: #78b0fd;
-      --c360-g-color-brand-inverse-contrast-3: var(--sds-g-color-brand-inverse-contrast-3);
+      --wes-g-color-brand-inverse-contrast-3: var(--sds-g-color-brand-inverse-contrast-3);
       /* Yellow 80 */
       --sds-g-color-palette-yellow-80: #fcc003;
-      --c360-g-color-palette-yellow-80: var(--sds-g-color-palette-yellow-80);
+      --wes-g-color-palette-yellow-80: var(--sds-g-color-palette-yellow-80);
       /* Pink 60 */
       --sds-g-color-palette-pink-60: #ff538a;
-      --c360-g-color-palette-pink-60: var(--sds-g-color-palette-pink-60);
+      --wes-g-color-palette-pink-60: var(--sds-g-color-palette-pink-60);
       /* Brand Base Contrast 4 - if used as a background, please use Brand Base 4 to meet accessibility guidelines. */
       --sds-g-color-brand-base-contrast-4: #001639;
-      --c360-g-color-brand-base-contrast-4: var(--sds-g-color-brand-base-contrast-4);
+      --wes-g-color-brand-base-contrast-4: var(--sds-g-color-brand-base-contrast-4);
       /* Error Base Contrast 3 - if used as a background, please use Error Base Base 3-4 to meet accessibility guidelines. */
       --sds-g-color-error-base-contrast-3: #8e030f;
-      --c360-g-color-error-base-contrast-3: var(--sds-g-color-error-base-contrast-3);
+      --wes-g-color-error-base-contrast-3: var(--sds-g-color-error-base-contrast-3);
       /* Red 20 */
       --sds-g-color-palette-red-20: #640103;
-      --c360-g-color-palette-red-20: var(--sds-g-color-palette-red-20);
+      --wes-g-color-palette-red-20: var(--sds-g-color-palette-red-20);
       /* Scaled font-size that is 4 stops smaller than the base. */
       --sds-g-font-scale-neg-4: 0.625rem;
       /* Blue 10 */
       --sds-g-color-palette-blue-10: #001639;
-      --c360-g-color-palette-blue-10: var(--sds-g-color-palette-blue-10);
+      --wes-g-color-palette-blue-10: var(--sds-g-color-palette-blue-10);
       /* Scaled font-size that is 7 stops bigger than the base. */
       --sds-g-font-scale-7: 2.281rem;
       /* Blue 65 */
       --sds-g-color-palette-blue-65: #57a3fd;
-      --c360-g-color-palette-blue-65: var(--sds-g-color-palette-blue-65);
+      --wes-g-color-palette-blue-65: var(--sds-g-color-palette-blue-65);
       /* Neutral Inverse Contrast 4 - if used as a background, please use Neutral Inverse Base 4 to meet accessibility guidelines. */
       --sds-g-color-neutral-inverse-contrast-4: #ffffff;
-      --c360-g-color-neutral-inverse-contrast-4: var(--sds-g-color-neutral-inverse-contrast-4);
+      --wes-g-color-neutral-inverse-contrast-4: var(--sds-g-color-neutral-inverse-contrast-4);
       /* Violet 15 */
       --sds-g-color-palette-violet-15: #3d0157;
-      --c360-g-color-palette-violet-15: var(--sds-g-color-palette-violet-15);
+      --wes-g-color-palette-violet-15: var(--sds-g-color-palette-violet-15);
       /* Brand Inverse Contrast 4 - if used as a background, please use Brand Inverse Base 4 to meet accessibility guidelines. */
       --sds-g-color-brand-inverse-contrast-4: #ffffff;
-      --c360-g-color-brand-inverse-contrast-4: var(--sds-g-color-brand-inverse-contrast-4);
+      --wes-g-color-brand-inverse-contrast-4: var(--sds-g-color-brand-inverse-contrast-4);
       /* Yellow 70 */
       --sds-g-color-palette-yellow-70: #e4a201;
-      --c360-g-color-palette-yellow-70: var(--sds-g-color-palette-yellow-70);
+      --wes-g-color-palette-yellow-70: var(--sds-g-color-palette-yellow-70);
       /* Pink 50 */
       --sds-g-color-palette-pink-50: #e3066a;
-      --c360-g-color-palette-pink-50: var(--sds-g-color-palette-pink-50);
+      --wes-g-color-palette-pink-50: var(--sds-g-color-palette-pink-50);
       /* Cloud Blue 90 */
       --sds-g-color-palette-cloud-blue-90: #cfe9fe;
-      --c360-g-color-palette-cloud-blue-90: var(--sds-g-color-palette-cloud-blue-90);
+      --wes-g-color-palette-cloud-blue-90: var(--sds-g-color-palette-cloud-blue-90);
       /* Indigo 90 */
       --sds-g-color-palette-indigo-90: #e0e5f8;
-      --c360-g-color-palette-indigo-90: var(--sds-g-color-palette-indigo-90);
+      --wes-g-color-palette-indigo-90: var(--sds-g-color-palette-indigo-90);
       /* Circular border radius for UI elements. */
       --sds-g-radius-border-circle: 100%;
-      --c360-g-radius-border-circle: var(--sds-g-radius-border-circle);
+      --wes-g-radius-border-circle: var(--sds-g-radius-border-circle);
       /* Error Base Contrast 4 - if used as a background, please use Error Base Base 4 to meet accessibility guidelines. */
       --sds-g-color-error-base-contrast-4: #640103;
-      --c360-g-color-error-base-contrast-4: var(--sds-g-color-error-base-contrast-4);
+      --wes-g-color-error-base-contrast-4: var(--sds-g-color-error-base-contrast-4);
       /* Red 10 */
       --sds-g-color-palette-red-10: #300c01;
-      --c360-g-color-palette-red-10: var(--sds-g-color-palette-red-10);
+      --wes-g-color-palette-red-10: var(--sds-g-color-palette-red-10);
       /* Red 65 */
       --sds-g-color-palette-red-65: #fe7765;
-      --c360-g-color-palette-red-65: var(--sds-g-color-palette-red-65);
+      --wes-g-color-palette-red-65: var(--sds-g-color-palette-red-65);
       /* Scaled font-size that is 8 stops bigger than the base. */
       --sds-g-font-scale-8: 2.566rem;
       /* Yellow 60 */
       --sds-g-color-palette-yellow-60: #ca8501;
-      --c360-g-color-palette-yellow-60: var(--sds-g-color-palette-yellow-60);
+      --wes-g-color-palette-yellow-60: var(--sds-g-color-palette-yellow-60);
       /* Pink 40 */
       --sds-g-color-palette-pink-40: #b60554;
-      --c360-g-color-palette-pink-40: var(--sds-g-color-palette-pink-40);
+      --wes-g-color-palette-pink-40: var(--sds-g-color-palette-pink-40);
       /* Cloud Blue 80 */
       --sds-g-color-palette-cloud-blue-80: #90d0fe;
-      --c360-g-color-palette-cloud-blue-80: var(--sds-g-color-palette-cloud-blue-80);
+      --wes-g-color-palette-cloud-blue-80: var(--sds-g-color-palette-cloud-blue-80);
       /* Pink 95 */
       --sds-g-color-palette-pink-95: #fef0f3;
-      --c360-g-color-palette-pink-95: var(--sds-g-color-palette-pink-95);
+      --wes-g-color-palette-pink-95: var(--sds-g-color-palette-pink-95);
       /* Indigo 80 */
       --sds-g-color-palette-indigo-80: #bec7f6;
-      --c360-g-color-palette-indigo-80: var(--sds-g-color-palette-indigo-80);
+      --wes-g-color-palette-indigo-80: var(--sds-g-color-palette-indigo-80);
       /* Scaled font-size that is 9 stops bigger than the base. */
       --sds-g-font-scale-9: 2.887rem;
       /* Yellow 50 */
       --sds-g-color-palette-yellow-50: #a86403;
-      --c360-g-color-palette-yellow-50: var(--sds-g-color-palette-yellow-50);
+      --wes-g-color-palette-yellow-50: var(--sds-g-color-palette-yellow-50);
       /* Pink 30 */
       --sds-g-color-palette-pink-30: #8a033e;
-      --c360-g-color-palette-pink-30: var(--sds-g-color-palette-pink-30);
+      --wes-g-color-palette-pink-30: var(--sds-g-color-palette-pink-30);
       /* Monospace font stack for your application. */
-      --c360-g-font-family-monospace: Consolas, Menlo, Monaco, Courier, monospace;
+      --wes-g-font-family-monospace: Consolas, Menlo, Monaco, Courier, monospace;
       /* Cloud Blue 70 */
       --sds-g-color-palette-cloud-blue-70: #1ab9ff;
-      --c360-g-color-palette-cloud-blue-70: var(--sds-g-color-palette-cloud-blue-70);
+      --wes-g-color-palette-cloud-blue-70: var(--sds-g-color-palette-cloud-blue-70);
       /* Indigo 70 */
       --sds-g-color-palette-indigo-70: #9ea9f1;
-      --c360-g-color-palette-indigo-70: var(--sds-g-color-palette-indigo-70);
+      --wes-g-color-palette-indigo-70: var(--sds-g-color-palette-indigo-70);
       /* Purple 15 */
       --sds-g-color-palette-purple-15: #300b60;
-      --c360-g-color-palette-purple-15: var(--sds-g-color-palette-purple-15);
+      --wes-g-color-palette-purple-15: var(--sds-g-color-palette-purple-15);
       /* Yellow 40 */
       --sds-g-color-palette-yellow-40: #8c4b02;
-      --c360-g-color-palette-yellow-40: var(--sds-g-color-palette-yellow-40);
+      --wes-g-color-palette-yellow-40: var(--sds-g-color-palette-yellow-40);
       /* Neutral 90 */
       --sds-g-color-palette-neutral-90: #e5e5e5;
-      --c360-g-color-palette-neutral-90: var(--sds-g-color-palette-neutral-90);
+      --wes-g-color-palette-neutral-90: var(--sds-g-color-palette-neutral-90);
       /* Pink 20 */
       --sds-g-color-palette-pink-20: #61022a;
-      --c360-g-color-palette-pink-20: var(--sds-g-color-palette-pink-20);
+      --wes-g-color-palette-pink-20: var(--sds-g-color-palette-pink-20);
       /* Yellow 95 */
       --sds-g-color-palette-yellow-95: #fbf3e0;
-      --c360-g-color-palette-yellow-95: var(--sds-g-color-palette-yellow-95);
+      --wes-g-color-palette-yellow-95: var(--sds-g-color-palette-yellow-95);
       /* Cloud Blue 60 */
       --sds-g-color-palette-cloud-blue-60: #0d9dda;
-      --c360-g-color-palette-cloud-blue-60: var(--sds-g-color-palette-cloud-blue-60);
+      --wes-g-color-palette-cloud-blue-60: var(--sds-g-color-palette-cloud-blue-60);
       /* Indigo 60 */
       --sds-g-color-palette-indigo-60: #7f8ced;
-      --c360-g-color-palette-indigo-60: var(--sds-g-color-palette-indigo-60);
+      --wes-g-color-palette-indigo-60: var(--sds-g-color-palette-indigo-60);
       /* Teal 15 */
       --sds-g-color-palette-teal-15: #072825;
-      --c360-g-color-palette-teal-15: var(--sds-g-color-palette-teal-15);
+      --wes-g-color-palette-teal-15: var(--sds-g-color-palette-teal-15);
       /* Yellow 30 */
       --sds-g-color-palette-yellow-30: #6f3400;
-      --c360-g-color-palette-yellow-30: var(--sds-g-color-palette-yellow-30);
+      --wes-g-color-palette-yellow-30: var(--sds-g-color-palette-yellow-30);
       /* Neutral 80 */
       --sds-g-color-palette-neutral-80: #c9c9c9;
-      --c360-g-color-palette-neutral-80: var(--sds-g-color-palette-neutral-80);
+      --wes-g-color-palette-neutral-80: var(--sds-g-color-palette-neutral-80);
       /* Pink 10 */
       --sds-g-color-palette-pink-10: #370114;
-      --c360-g-color-palette-pink-10: var(--sds-g-color-palette-pink-10);
+      --wes-g-color-palette-pink-10: var(--sds-g-color-palette-pink-10);
       /* Orange 90 */
       --sds-g-color-palette-orange-90: #fedfd0;
-      --c360-g-color-palette-orange-90: var(--sds-g-color-palette-orange-90);
+      --wes-g-color-palette-orange-90: var(--sds-g-color-palette-orange-90);
       /* Cloud Blue 50 */
       --sds-g-color-palette-cloud-blue-50: #107cad;
-      --c360-g-color-palette-cloud-blue-50: var(--sds-g-color-palette-cloud-blue-50);
+      --wes-g-color-palette-cloud-blue-50: var(--sds-g-color-palette-cloud-blue-50);
       /* Pink 65 */
       --sds-g-color-palette-pink-65: #fe7298;
-      --c360-g-color-palette-pink-65: var(--sds-g-color-palette-pink-65);
+      --wes-g-color-palette-pink-65: var(--sds-g-color-palette-pink-65);
       /* Indigo 50 */
       --sds-g-color-palette-indigo-50: #5867e8;
-      --c360-g-color-palette-indigo-50: var(--sds-g-color-palette-indigo-50);
+      --wes-g-color-palette-indigo-50: var(--sds-g-color-palette-indigo-50);
       /* Hot Orange 90 */
       --sds-g-color-palette-hot-orange-90: #ffded5;
-      --c360-g-color-palette-hot-orange-90: var(--sds-g-color-palette-hot-orange-90);
+      --wes-g-color-palette-hot-orange-90: var(--sds-g-color-palette-hot-orange-90);
       /* Default color on focus for hyperlinks. */
       --sds-g-link-color-focus: #014486;
-      --c360-g-link-color-focus: var(--sds-g-link-color-focus);
+      --wes-g-link-color-focus: var(--sds-g-link-color-focus);
       /* Blue 15 */
       --sds-g-color-palette-blue-15: #03234d;
-      --c360-g-color-palette-blue-15: var(--sds-g-color-palette-blue-15);
+      --wes-g-color-palette-blue-15: var(--sds-g-color-palette-blue-15);
       /* Yellow 20 */
       --sds-g-color-palette-yellow-20: #4f2100;
-      --c360-g-color-palette-yellow-20: var(--sds-g-color-palette-yellow-20);
+      --wes-g-color-palette-yellow-20: var(--sds-g-color-palette-yellow-20);
       /* Neutral 70 */
       --sds-g-color-palette-neutral-70: #aeaeae;
-      --c360-g-color-palette-neutral-70: var(--sds-g-color-palette-neutral-70);
+      --wes-g-color-palette-neutral-70: var(--sds-g-color-palette-neutral-70);
       /* Orange 80 */
       --sds-g-color-palette-orange-80: #ffba90;
-      --c360-g-color-palette-orange-80: var(--sds-g-color-palette-orange-80);
+      --wes-g-color-palette-orange-80: var(--sds-g-color-palette-orange-80);
       /* Cloud Blue 40 */
       --sds-g-color-palette-cloud-blue-40: #05628a;
-      --c360-g-color-palette-cloud-blue-40: var(--sds-g-color-palette-cloud-blue-40);
+      --wes-g-color-palette-cloud-blue-40: var(--sds-g-color-palette-cloud-blue-40);
       /* Indigo 40 */
       --sds-g-color-palette-indigo-40: #3a49da;
-      --c360-g-color-palette-indigo-40: var(--sds-g-color-palette-indigo-40);
+      --wes-g-color-palette-indigo-40: var(--sds-g-color-palette-indigo-40);
       /* Hot Orange 80 */
       --sds-g-color-palette-hot-orange-80: #feb9a5;
-      --c360-g-color-palette-hot-orange-80: var(--sds-g-color-palette-hot-orange-80);
+      --wes-g-color-palette-hot-orange-80: var(--sds-g-color-palette-hot-orange-80);
       /* Cloud Blue 95 */
       --sds-g-color-palette-cloud-blue-95: #eaf5fe;
-      --c360-g-color-palette-cloud-blue-95: var(--sds-g-color-palette-cloud-blue-95);
+      --wes-g-color-palette-cloud-blue-95: var(--sds-g-color-palette-cloud-blue-95);
       /* Indigo 95 */
       --sds-g-color-palette-indigo-95: #f1f3fb;
-      --c360-g-color-palette-indigo-95: var(--sds-g-color-palette-indigo-95);
+      --wes-g-color-palette-indigo-95: var(--sds-g-color-palette-indigo-95);
       /* Red 15 */
       --sds-g-color-palette-red-15: #4a0c04;
-      --c360-g-color-palette-red-15: var(--sds-g-color-palette-red-15);
+      --wes-g-color-palette-red-15: var(--sds-g-color-palette-red-15);
       /* Bold font-weight, use to increase emphasis. */
       --sds-g-font-weight-bold: bold;
-      --c360-g-font-weight-bold: var(--sds-g-font-weight-bold);
+      --wes-g-font-weight-bold: var(--sds-g-font-weight-bold);
       /* Yellow 10 */
       --sds-g-color-palette-yellow-10: #281202;
-      --c360-g-color-palette-yellow-10: var(--sds-g-color-palette-yellow-10);
+      --wes-g-color-palette-yellow-10: var(--sds-g-color-palette-yellow-10);
       /* Neutral 60 */
       --sds-g-color-palette-neutral-60: #939393;
-      --c360-g-color-palette-neutral-60: var(--sds-g-color-palette-neutral-60);
+      --wes-g-color-palette-neutral-60: var(--sds-g-color-palette-neutral-60);
       /* Yellow 65 */
       --sds-g-color-palette-yellow-65: #d79304;
-      --c360-g-color-palette-yellow-65: var(--sds-g-color-palette-yellow-65);
+      --wes-g-color-palette-yellow-65: var(--sds-g-color-palette-yellow-65);
       /* Orange 70 */
       --sds-g-color-palette-orange-70: #fe9339;
-      --c360-g-color-palette-orange-70: var(--sds-g-color-palette-orange-70);
+      --wes-g-color-palette-orange-70: var(--sds-g-color-palette-orange-70);
       /* Cloud Blue 30 */
       --sds-g-color-palette-cloud-blue-30: #084968;
-      --c360-g-color-palette-cloud-blue-30: var(--sds-g-color-palette-cloud-blue-30);
+      --wes-g-color-palette-cloud-blue-30: var(--sds-g-color-palette-cloud-blue-30);
       /* Indigo 30 */
       --sds-g-color-palette-indigo-30: #2f2cb7;
-      --c360-g-color-palette-indigo-30: var(--sds-g-color-palette-indigo-30);
+      --wes-g-color-palette-indigo-30: var(--sds-g-color-palette-indigo-30);
       /* Hot Orange 70 */
       --sds-g-color-palette-hot-orange-70: #ff906e;
-      --c360-g-color-palette-hot-orange-70: var(--sds-g-color-palette-hot-orange-70);
+      --wes-g-color-palette-hot-orange-70: var(--sds-g-color-palette-hot-orange-70);
       /* Inversed border color for UI elements. */
       --sds-g-color-border-inverse-1: #181818;
-      --c360-g-color-border-inverse-1: var(--sds-g-color-border-inverse-1);
+      --wes-g-color-border-inverse-1: var(--sds-g-color-border-inverse-1);
       /* Neutral 50 */
       --sds-g-color-palette-neutral-50: #747474;
-      --c360-g-color-palette-neutral-50: var(--sds-g-color-palette-neutral-50);
+      --wes-g-color-palette-neutral-50: var(--sds-g-color-palette-neutral-50);
       /* Orange 60 */
       --sds-g-color-palette-orange-60: #dd7a01;
-      --c360-g-color-palette-orange-60: var(--sds-g-color-palette-orange-60);
+      --wes-g-color-palette-orange-60: var(--sds-g-color-palette-orange-60);
       /* Cloud Blue 20 */
       --sds-g-color-palette-cloud-blue-20: #023248;
-      --c360-g-color-palette-cloud-blue-20: var(--sds-g-color-palette-cloud-blue-20);
+      --wes-g-color-palette-cloud-blue-20: var(--sds-g-color-palette-cloud-blue-20);
       /* Green 90 */
       --sds-g-color-palette-green-90: #cdefc4;
-      --c360-g-color-palette-green-90: var(--sds-g-color-palette-green-90);
+      --wes-g-color-palette-green-90: var(--sds-g-color-palette-green-90);
       /* Indigo 20 */
       --sds-g-color-palette-indigo-20: #260f8f;
-      --c360-g-color-palette-indigo-20: var(--sds-g-color-palette-indigo-20);
+      --wes-g-color-palette-indigo-20: var(--sds-g-color-palette-indigo-20);
       /* Hot Orange 60 */
       --sds-g-color-palette-hot-orange-60: #ff5d2d;
-      --c360-g-color-palette-hot-orange-60: var(--sds-g-color-palette-hot-orange-60);
+      --wes-g-color-palette-hot-orange-60: var(--sds-g-color-palette-hot-orange-60);
       /* Neutral 40 */
       --sds-g-color-palette-neutral-40: #5c5c5c;
-      --c360-g-color-palette-neutral-40: var(--sds-g-color-palette-neutral-40);
+      --wes-g-color-palette-neutral-40: var(--sds-g-color-palette-neutral-40);
       /* Alternate inversed border color for UI elements. */
       --sds-g-color-border-inverse-2: #2e2e2e;
-      --c360-g-color-border-inverse-2: var(--sds-g-color-border-inverse-2);
+      --wes-g-color-border-inverse-2: var(--sds-g-color-border-inverse-2);
       /* Orange 50 */
       --sds-g-color-palette-orange-50: #a96404;
-      --c360-g-color-palette-orange-50: var(--sds-g-color-palette-orange-50);
+      --wes-g-color-palette-orange-50: var(--sds-g-color-palette-orange-50);
       /* Cloud Blue 10 */
       --sds-g-color-palette-cloud-blue-10: #001a28;
-      --c360-g-color-palette-cloud-blue-10: var(--sds-g-color-palette-cloud-blue-10);
+      --wes-g-color-palette-cloud-blue-10: var(--sds-g-color-palette-cloud-blue-10);
       /* Neutral 95 */
       --sds-g-color-palette-neutral-95: #f3f3f3;
-      --c360-g-color-palette-neutral-95: var(--sds-g-color-palette-neutral-95);
+      --wes-g-color-palette-neutral-95: var(--sds-g-color-palette-neutral-95);
       /* Green 80 */
       --sds-g-color-palette-green-80: #91db8b;
-      --c360-g-color-palette-green-80: var(--sds-g-color-palette-green-80);
+      --wes-g-color-palette-green-80: var(--sds-g-color-palette-green-80);
       /* Indigo 10 */
       --sds-g-color-palette-indigo-10: #200647;
-      --c360-g-color-palette-indigo-10: var(--sds-g-color-palette-indigo-10);
+      --wes-g-color-palette-indigo-10: var(--sds-g-color-palette-indigo-10);
       /* Hot Orange 50 */
       --sds-g-color-palette-hot-orange-50: #d83a00;
-      --c360-g-color-palette-hot-orange-50: var(--sds-g-color-palette-hot-orange-50);
+      --wes-g-color-palette-hot-orange-50: var(--sds-g-color-palette-hot-orange-50);
       /* Cloud Blue 65 */
       --sds-g-color-palette-cloud-blue-65: #08abed;
-      --c360-g-color-palette-cloud-blue-65: var(--sds-g-color-palette-cloud-blue-65);
+      --wes-g-color-palette-cloud-blue-65: var(--sds-g-color-palette-cloud-blue-65);
       /* Indigo 65 */
       --sds-g-color-palette-indigo-65: #8e9bef;
-      --c360-g-color-palette-indigo-65: var(--sds-g-color-palette-indigo-65);
+      --wes-g-color-palette-indigo-65: var(--sds-g-color-palette-indigo-65);
       /* Default color on hover for hyperlinks. */
       --sds-g-link-color-hover: #014486;
-      --c360-g-link-color-hover: var(--sds-g-link-color-hover);
+      --wes-g-link-color-hover: var(--sds-g-link-color-hover);
       /* Default font-size for your application. */
       --sds-g-font-size-base: 1rem;
       /* Neutral 30 */
       --sds-g-color-palette-neutral-30: #444444;
-      --c360-g-color-palette-neutral-30: var(--sds-g-color-palette-neutral-30);
+      --wes-g-color-palette-neutral-30: var(--sds-g-color-palette-neutral-30);
       /* Orange 40 */
       --sds-g-color-palette-orange-40: #825101;
-      --c360-g-color-palette-orange-40: var(--sds-g-color-palette-orange-40);
+      --wes-g-color-palette-orange-40: var(--sds-g-color-palette-orange-40);
       /* Pink 15 */
       --sds-g-color-palette-pink-15: #4b0620;
-      --c360-g-color-palette-pink-15: var(--sds-g-color-palette-pink-15);
+      --wes-g-color-palette-pink-15: var(--sds-g-color-palette-pink-15);
       /* Green 70 */
       --sds-g-color-palette-green-70: #45c65a;
-      --c360-g-color-palette-green-70: var(--sds-g-color-palette-green-70);
+      --wes-g-color-palette-green-70: var(--sds-g-color-palette-green-70);
       /* Hot Orange 40 */
       --sds-g-color-palette-hot-orange-40: #aa3001;
-      --c360-g-color-palette-hot-orange-40: var(--sds-g-color-palette-hot-orange-40);
+      --wes-g-color-palette-hot-orange-40: var(--sds-g-color-palette-hot-orange-40);
       /* Orange 95 */
       --sds-g-color-palette-orange-95: #fff1ea;
-      --c360-g-color-palette-orange-95: var(--sds-g-color-palette-orange-95);
+      --wes-g-color-palette-orange-95: var(--sds-g-color-palette-orange-95);
       /* Hot Orange 95 */
       --sds-g-color-palette-hot-orange-95: #fef1ed;
-      --c360-g-color-palette-hot-orange-95: var(--sds-g-color-palette-hot-orange-95);
+      --wes-g-color-palette-hot-orange-95: var(--sds-g-color-palette-hot-orange-95);
       /* Border size 1. */
       --sds-g-sizing-border-1: 1px;
-      --c360-g-sizing-border-1: var(--sds-g-sizing-border-1);
+      --wes-g-sizing-border-1: var(--sds-g-sizing-border-1);
       /* System font stack for your application. */
-      --c360-g-font-family-display: 'ITC Avant Garde', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+      --wes-g-font-family-display: 'ITC Avant Garde', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       /* System font stack for your application. */
-      --c360-g-font-family-sans: 'Salesforce Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+      --wes-g-font-family-sans: 'Salesforce Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
       /* Scaled font-size that is 1 stop bigger than the base. */
-      --c360-g-font-size-1: 0.75rem;
+      --wes-g-font-size-1: 0.75rem;
       /* Scaled font-size that is 2 stops bigger than the base. */
-      --c360-g-font-size-2: 0.875rem;
+      --wes-g-font-size-2: 0.875rem;
       /* Scaled font-size that is 3 stops bigger than the base. */
-      --c360-g-font-size-3: 1rem;
+      --wes-g-font-size-3: 1rem;
       /* Scaled font-size that is 4 stops bigger than the base. */
-      --c360-g-font-size-4: 1.25rem;
+      --wes-g-font-size-4: 1.25rem;
       /* Scaled font-size that is 5 stops bigger than the base. */
-      --c360-g-font-size-5: 1.5rem;
+      --wes-g-font-size-5: 1.5rem;
       /* Scaled font-size that is 6 stops bigger than the base. */
-      --c360-g-font-size-6: 2rem;
+      --wes-g-font-size-6: 2rem;
       /* Scaled font-size that is 7 stops bigger than the base. */
-      --c360-g-font-size-7: 2.5rem;
+      --wes-g-font-size-7: 2.5rem;
       /* Scaled font-size that is 8 stops bigger than the base. */
-      --c360-g-font-size-8: 3rem;
+      --wes-g-font-size-8: 3rem;
       /* Scaled font-size that is 9 stops bigger than the base. */
-      --c360-g-font-size-9: 3.5rem;
+      --wes-g-font-size-9: 3.5rem;
       /* Scaled font-size that is 10 stops bigger than the base. */
-      --c360-g-font-size-10: 5rem;
+      --wes-g-font-size-10: 5rem;
+      /* Kinetics x-long duration */
+      --wes-g-kx-duration-x-long: 600ms;
+      /* Kinetics long duration */
+      --wes-g-kx-duration-long: 400ms;
+      /* Kinetics normal duration */
+      --wes-g-kx-duration-normal: 250ms;
+      /* Kinetics short duration */
+      --wes-g-kx-duration-short: 150ms;
+      /* Kinetics short duration */
+      --wes-g-kx-duration-x-short: 75ms;
+      /* Kinetics ease none */
+      --wes-g-kx-ease-none: cubic-bezier(0, 0, 1, 1);
+      /* Kinetics ease in */
+      --wes-g-kx-ease-in: cubic-bezier(0.3, 0, 1, 0.3);
+      /* Kinetics ease out */
+      --wes-g-kx-ease-out: cubic-bezier(0, 0.3, 0.15, 1);
+      /* Kinetics ease in-out */
+      --wes-g-kx-ease-in-out: cubic-bezier(0.3, 0, 0.15, 1);
+      /* Kinetics ease under */
+      --wes-g-kx-ease-under: cubic-bezier(0.7, 0, 0.7, -0.75);
+      /* Kinetics ease over */
+      --wes-g-kx-ease-over: cubic-bezier(0.3, 1.75, 0.3, 1);
   }
   

--- a/src/modules/home/app/app.css
+++ b/src/modules/home/app/app.css
@@ -1,4 +1,4 @@
-@import '@salesforce-ux/c360-grid/dist/index.css';
+@import '@salesforce-ux/wes-grid/dist/index.css';
 
 main {
   padding: 2rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,10 +755,10 @@
     "@lwrjs/diagnostics" "0.6.0-alpha.14"
     "@lwrjs/shared-utils" "0.6.0-alpha.14"
 
-"@oneappexchange/appx-design-system@0.0.1-alpha.4":
-  version "0.0.1-alpha.4"
-  resolved "https://npm.pkg.github.com/download/@oneappexchange/appx-design-system/0.0.1-alpha.4/ab57347fadf777aa46fe8857aeef24fb7f7677ea696d16d4c79215e7d4acbae6#79bec446d2cccc4e65838ef185d0126afb864b1a"
-  integrity sha512-svxQOTHD5La1qMaP7djV/uTngazti1FMp0jJ5Hcsjk5cimrUBe+yuyV2X+zZZsaa7H/FUUTX95s7eW62lc20kw==
+"@oneappexchange/appx-design-system@^0.0.1-alpha.7":
+  version "0.0.1-alpha.7"
+  resolved "https://npm.pkg.github.com/download/@OneAppExchange/appx-design-system/0.0.1-alpha.7/5651f30f33e1ea61b6559827414c08967206df91#5651f30f33e1ea61b6559827414c08967206df91"
+  integrity sha512-OaPiEkbMYHyr+B4w6hbBZ5WavrmwjSrsh1N8ndLU26C1OjpdooSQ6NXSi0i891EX+SMMoKxBw7rf6HO+Cvgj9w==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -871,35 +871,35 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@salesforce-ux/c360-grid@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@salesforce-ux/c360-grid/-/c360-grid-0.1.5.tgz#efe0d4ac80a459f4a8154615c03dae0f3812e192"
-  integrity sha512-TT+LUDZxun+uixXtn33AEdlkyFAKVmZksWZ9I+dr5PlAtQsvGVivTwaBB2O3H1XyJ8S5me03oQnHuPorKkvdgQ==
-  dependencies:
-    "@salesforce-ux/sds-grid" "^0.2.7"
-
-"@salesforce-ux/c360-styling-hooks@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@salesforce-ux/c360-styling-hooks/-/c360-styling-hooks-0.2.2.tgz#add959d1c409c4e2af9e7bc6407e0af1e790a8c3"
-  integrity sha512-3sN0/OxnamlFTsQaL4uo8rHEBQSXt+cH34AjrMUdDXqXx8JJRNliI9qxd6t/UGhSfns/M2NPrExLyKLIo65YrA==
-  dependencies:
-    "@salesforce-ux/sds-styling-aliases" "^0.2.0"
-    "@salesforce-ux/sds-styling-hooks" "^0.7.0"
-
 "@salesforce-ux/sds-grid@^0.2.7":
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/@salesforce-ux/sds-grid/-/sds-grid-0.2.8.tgz#2d44cc962946c40924e9ecfd8ba61bf5cbc8816c"
   integrity sha512-DY1T6UxbsUulAuR18pzjqqhToUDP5rsysgHBPBfERx2OexFQEgGbO8aKgmT63EafT8Tax+LXe06na5IxjDFpSw==
 
-"@salesforce-ux/sds-styling-aliases@^0.2.0":
+"@salesforce-ux/sds-styling-aliases@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@salesforce-ux/sds-styling-aliases/-/sds-styling-aliases-0.2.3.tgz#3c5f494b58756798da98ddcc2ae7e403e8fa3a85"
   integrity sha512-M6riDnVx19FN2s7Q+OFs6EyED3q/ssR8bsY3H2QKB8WNUEOOdRFw26pAU7SmWr/WSiTdQP5Z+u3iSUDJJWZqzw==
 
-"@salesforce-ux/sds-styling-hooks@^0.7.0":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@salesforce-ux/sds-styling-hooks/-/sds-styling-hooks-0.7.1.tgz#b8ebc0b62d192ae6c651adcbcf2ddf081951098e"
-  integrity sha512-1OEGGmZlByzyiPZslEyb9KKGhbk2LQOOykzhRreFAucyAdU8fj5er1uPY7xvDpvD3tAIQh5+JcV7HvqPw7um5w==
+"@salesforce-ux/sds-styling-hooks@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@salesforce-ux/sds-styling-hooks/-/sds-styling-hooks-0.7.0.tgz#ae8014a707d5d082352f9d1d919add9a9c6e2abd"
+  integrity sha512-VXz1/aKAFCLngUdf5IU9BybNWkfNJBS+yR5KFbwMAjGk1MZ+rghfnEHqbddE7E2KSOKGbszNBMW8/FUCTeRjIQ==
+
+"@salesforce-ux/wes-grid@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@salesforce-ux/wes-grid/-/wes-grid-0.0.1.tgz#8b8d3ec101a5735f9a8a7dc73cb351bc693c16c1"
+  integrity sha512-HNab608iMzttc4oc9JW58lVTs+sJLvZncRlsFn/1TVJMSzWqVnJGJVA60TOSjjZcaLmJ9RQEKQzG6aKQC3cv+Q==
+  dependencies:
+    "@salesforce-ux/sds-grid" "^0.2.7"
+
+"@salesforce-ux/wes-styling-hooks@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@salesforce-ux/wes-styling-hooks/-/wes-styling-hooks-0.0.1.tgz#ff53d733abfb17e327948c22a5198fa37e4de9a9"
+  integrity sha512-qWyzIdrqVxhM6jRhwenWLylaJUn5DcIg0IcXG76yI9M0fq7aWgh+AtlvZ/Diq0uYKfG6/PkcOTIXvpN4uBGOyw==
+  dependencies:
+    "@salesforce-ux/sds-styling-aliases" "^0.2.3"
+    "@salesforce-ux/sds-styling-hooks" "0.7.0"
 
 "@tootallnate/once@1":
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,10 +755,10 @@
     "@lwrjs/diagnostics" "0.6.0-alpha.14"
     "@lwrjs/shared-utils" "0.6.0-alpha.14"
 
-"@oneappexchange/appx-design-system@^0.0.1-alpha.7":
-  version "0.0.1-alpha.7"
-  resolved "https://npm.pkg.github.com/download/@OneAppExchange/appx-design-system/0.0.1-alpha.7/5651f30f33e1ea61b6559827414c08967206df91#5651f30f33e1ea61b6559827414c08967206df91"
-  integrity sha512-OaPiEkbMYHyr+B4w6hbBZ5WavrmwjSrsh1N8ndLU26C1OjpdooSQ6NXSi0i891EX+SMMoKxBw7rf6HO+Cvgj9w==
+"@oneappexchange/appx-design-system@^0.0.1-alpha.8":
+  version "0.0.1-alpha.8"
+  resolved "https://npm.pkg.github.com/download/@OneAppExchange/appx-design-system/0.0.1-alpha.8/648e145c5e6a57e747c5ce7c0629b04877db6ee7#648e145c5e6a57e747c5ce7c0629b04877db6ee7"
+  integrity sha512-STVPXhG70qe2qdnX8LTgNtOLAEVkA88s8vCFv3KMhM03iBUAN+AmU6uq0y6Y4zDP9KLYCyG4/U1UrWD44z1hxw==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
The https://github.com/salesforce-ux/c360-subsystem, or `c360` namespace has been deprecated in favour of https://github.com/salesforce-ux/website-experience-subsystem, or `wes`.

This PR updates the dependencies to use `wes` packages, like https://www.npmjs.com/package/@salesforce-ux/wes-styling-hooks, and updates documentation.

**This is a draft**, as the dependency on `appx-design-system` would need to be updated first once that is live before this can be merged.

Parent PR:
- https://github.com/OneAppExchange/appx-design-system/pull/32